### PR TITLE
ML-DSA-44 or 65 example?

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.xml
+++ b/draft-ietf-lamps-dilithium-certificates.xml
@@ -265,7 +265,7 @@
 		 of type BIT STRING) as follows: the most significant bit of the OCTET STRING value becomes the most significant
 		 bit of the BIT STRING value, and so on; the least significant bit of the OCTET STRING becomes the least significant
 		 bit of the BIT STRING. </t>
-         <t>The following is an example of the ML-DSA-44 public key (for the seed 000102…1e1f) encoded using the textual encoding defined in
+         <t>The following is an example of the ML-DSA-65 public key (for the seed 000102…1e1f) encoded using the textual encoding defined in
 		 <xref target="RFC7468"/>.</t>
          <!-- examples/ML-DSA-44.pub -->
          <artwork>

--- a/draft-ietf-lamps-dilithium-certificates.xml
+++ b/draft-ietf-lamps-dilithium-certificates.xml
@@ -264,7 +264,7 @@
 		 of type BIT STRING) as follows: the most significant bit of the OCTET STRING value becomes the most significant
 		 bit of the BIT STRING value, and so on; the least significant bit of the OCTET STRING becomes the least significant
 		 bit of the BIT STRING. </t>
-         <t>The following is an example of the ML-DSA-65 public key (for the seed 000102…1e1f) encoded using the textual encoding defined in
+         <t>The following is an example of the ML-DSA-44 public key (for the seed 000102…1e1f) encoded using the textual encoding defined in
 		 <xref target="RFC7468"/>.</t>
          <!-- examples/ML-DSA-44.pub -->
          <artwork>

--- a/draft-ietf-lamps-dilithium-certificates.xml
+++ b/draft-ietf-lamps-dilithium-certificates.xml
@@ -257,8 +257,7 @@
   MLDSAPublicKey ::= OCTET STRING
       </sourcecode>
       <t>where MLDSAPublicKey is a ML-DSA public key as specified by FIPS 204.
-      Sizes for the three security levels are specified are given in <xref target="MLS-DSAParameters"/>.
-          These parameters <bcp14>MUST</bcp14> be encoded as a single OCTET STRING.</t>
+      Sizes for the three security levels are specified are given in <xref target="MLS-DSAParameters"/>.</t>
          <t>The id-ML-DSA identifier defined in <xref target="oids"/> <bcp14>MUST</bcp14> be used as the algorithm field in the
 		 SubjectPublicKeyInfo sequence <xref target="RFC5280" format="default"/> to identify a ML-DSA public key.</t>
          <t>The ML-DSA public key (a concatenation of rho and t1 that is an OCTET STRING) is mapped to a subjectPublicKey (a value


### PR DESCRIPTION
The public key example looks to be from ML-DSA-65. The public key example looks to have an OID that ends in 65 and also 1.8KB size. So, it is ML-DSA-65, right @jakemas ?

Also, I am not sure what 
> These parameters MUST be encoded as a single OCTET STRING.
is referring to. @jakemas 