### PR TITLE
Section 4 and Section 6 rewrite

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -336,7 +336,7 @@ present:
 Requirements about the keyUsage extension bits defined in {{RFC5280}}
 still apply.
 
-#  ML-DSA Private Keys
+#  Private Key Format
 
 An ML-DSA private key is encoded by storing its 32-octet seed in
 the privateKey field as follows.

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -378,7 +378,7 @@ OneAsymmetricKey is replicated below.
 </aside>
 
 When used in a OneAsymmetricKey type, the privateKey OCTET STRING contains
-the raw octet string encoding of the 64-octet seed. The publicKey field
+the raw octet string encoding of the 32-octet seed. The publicKey field
 SHOULD be omitted because the public key can be computed as noted earlier
 in this section.
 


### PR DESCRIPTION
To address comments regarding the use of OCTET vs BIT STRING for private/public key encoding, I am modifying the draft to be more consistent with [draft-ietf-lamps-kyber-certificates](https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/) and [draft-ietf-lamps-x509-slhdsa](https://datatracker.ietf.org/doc/draft-ietf-lamps-x509-slhdsa/).

