### PR TITLE
Adding ExternalMu-ML-DSA

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -394,20 +394,20 @@ in this section.
 {{examples}} contains example ML-DSA private keys encoded using the
 textual encoding defined in {{RFC7468}}.
 
-# Pre-hashed mode (ExtarnalMu-ML-DSA)
+# Pre-hashed mode (ExternalMu-ML-DSA)
 
 
 Many applications will require a "pre-hashed" mode of ML-DSA whereby a message digest can be pre-computed outside of the cryptographic module and then only a small fixed-width hash value is passed to the crypto module.
 Many applications and protocols include message digesting, but there exist some that do not. Examples of this can be found even within [RFC5280]; for example certificate and certificate revocation list (CRL) data structures do not include message digesting and therefore become problematic when producing large CRLs or when signing a high volume of certificates containing large public keys. Such situations require pre-hashing to be performed by the signature primitive.
 
 
-This section presents the "ExternalMu-ML-DSA" signature mode which provides an interface for performing pre-hashed signatures in a way which is both compliant with [FIPS204] and which produces signatures values which are indistinguishable from signatures produced by ML-DSA.Sign() and are therefore compatible with the normal ML-DSA.Verify() and are identified by the same Object Identifiers as for ML-DSA. A ML-DSA key and certificate MAY be used with either ML-DSA or ExternalMu-ML-DSA interchangeably. Note that ExternalMu-ML-DSA describes a different signature API from ML-DSA and therefore might require explicit support from hardware or software cryptographic modules.
+This section presents the "ExternalMu-ML-DSA" processing flow which is composed of a new pre-hashing step `ExternalMu-ML-DSA.Prehash()` followed by alternate versions of `Sign()` (originally defined in [FIPS204] Algorithm 2) and `Sign_internal()` (originally defined in [FIPS204] Algorithm 7) which together provide an interface for performing pre-hashed signatures as specified in [FIPS204], which produces signature values which are indistinguishable from signatures produced by ML-DSA.Sign() and are therefore compatible with the normal ML-DSA.Verify() and are identified by the same Object Identifiers as for ML-DSA. A ML-DSA key and certificate MAY be used with either ML-DSA or ExternalMu-ML-DSA interchangeably. Note that ExternalMu-ML-DSA describes a different signature API from ML-DSA and therefore might require explicit support from hardware or software cryptographic modules.
 
-Note that the signing mode defined here is different from HashML-DSA defined in [FIPS204] section 5.4. This specification uses exclusively ExternalMu-ML-DSA for pre-hashed use cases, and thus HashML-DSA as defined in [FIPS204] and identified by `id-hash-ml-dsa-44-with-sha512`, `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512` MUST NOT be be used in X.509 and related PKIX protocols.
+Note that the signing mode defined here is different from HashML-DSA defined in [FIPS204] section 5.4. This specification uses exclusively ExternalMu-ML-DSA for pre-hashed use cases, and thus HashML-DSA as defined in [FIPS204] and identified by `id-hash-ml-dsa-44-with-sha512`, `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512` MUST NOT be used in X.509 and related PKIX protocols.
 
-The procedures below present modified versions of Algorithm 2 and Algorithm 7 in [FIPS204]. Note that all functions and notation used in {{fig-externalmu-ml-dsa-external}} and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].
+All functions and notation used in {{fig-externalmu-ml-dsa-external}} and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].
 
-External operations that are to be performed outside of the cryptographic module.
+External operations:
 
 ~~~
 ExternalMu-ML-DSA.Prehash(pk, M, ctx):
@@ -426,10 +426,15 @@ ExternalMu-ML-DSA.Prehash(pk, M, ctx):
 
 
 
-Internal operations that are to be performed inside of the cryptographic module.
+Internal operations:
 
 ~~~
 ExternalMu-ML-DSA.Sign(sk, mu):
+
+  if |mu| != 512 then
+    return error  # return an error indication if the input mu is not
+                  # 64 bytes (512 bits).
+  end if
 
   rnd = rand(32)  # for the optional deterministic variant,
                   # substitute rnd = 0x0 * 32

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -160,6 +160,15 @@ specifies the use of the ML-DSA in Public Key Infrastructure X.509 (PKIX)
 certificates and Certificate Revocation Lists (CRLs) at three security
 levels: ML-DSA-44, ML-DSA-65, and ML-DSA-87.
 
+{{FIPS204}} defines two variants of ML-DSA: a pure and a prehash variant.
+Only the former is specified in this document.
+The pure variant of ML-DSA supports the typical prehash flow:
+one cryptographic module can compute the hash *mu*
+on line 6 of algorithm 7 of {{FIPS204}} and pass it to a second module
+to finish the signature. The first module only needs access to the full
+message and the public key, whereas the second module only needs access
+to hash *mu* and the private key.
+
 ## Requirements Language
 
 {::boilerplate bcp14-tagged}

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -394,6 +394,59 @@ in this section.
 {{examples}} contains example ML-DSA private keys encoded using the
 textual encoding defined in {{RFC7468}}.
 
+# Pre-hashed mode (ExtarnalMu-ML-DSA)
+
+
+Many applications will require a "pre-hashed" mode of ML-DSA whereby a message digest can be pre-computed outside of the cryptographic module and then only a small fixed-width hash value is passed to the crypto module.
+Many applications and protocols include message digesting, but there exist some that do not. Examples of this can be found even within [RFC5280]; for example certificate and certificate revocation list (CRL) data structures do not include message digesting and therefore become problematic when producing large CRLs or when signing a high volume of certificates containing large public keys. Such situations require pre-hashing to be performed by the signature primitive.
+
+
+This section presents the "ExternalMu-ML-DSA" signature mode which provides an interface for performing pre-hashed signatures in a way which is both compliant with [FIPS204] and which produces signatures values which are indistinguishable from signatures produced by ML-DSA.Sign() and are therefore compatible with the normal ML-DSA.Verify() and are identified by the same Object Identifiers as for ML-DSA. A ML-DSA key and certificate MAY be used with either ML-DSA or ExternalMu-ML-DSA interchangeably. Note that ExternalMu-ML-DSA describes a different signature API from ML-DSA and therefore might require explicit support from hardware or software cryptographic modules.
+
+Note that the signing mode defined here is different from HashML-DSA defined in [FIPS204] section 5.4. This specification uses exclusively ExternalMu-ML-DSA for pre-hashed use cases, and thus HashML-DSA as defined in [FIPS204] and identified by `id-hash-ml-dsa-44-with-sha512`, `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512` MUST NOT be be used in X.509 and related PKIX protocols.
+
+The procedures below present modified versions of Algorithm 2 and Algorithm 7 in [FIPS204]. Note that all functions and notation used in {{fig-externalmu-ml-dsa-external}} and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].
+
+External operations that are to be performed outside of the cryptographic module.
+
+~~~
+ExternalMu-ML-DSA.Prehash(pk, M, ctx):
+
+  if |ctx| > 255 then
+    return error  # return an error indication if the context string is
+                  # too long
+  end if
+
+  M' = BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|ctx|, 1)
+                                                        || ctx) || M
+  mu = H(BytesToBits(pk.tr) || M', 64)
+  return mu
+~~~
+{: #fig-externalmu-ml-dsa-external title="External steps of ExternalMu-ML-DSA"}
+
+
+
+Internal operations that are to be performed inside of the cryptographic module.
+
+~~~
+ExternalMu-ML-DSA.Sign(sk, mu):
+
+  rnd = rand(32)  # for the optional deterministic variant,
+                  # substitute rnd = 0x0 * 32
+  if rnd = NULL then
+    return error  # return an error indication if random bit
+                  # generation failed
+  end if
+
+  sigma = ExternalMu-ML-DSA.Sign_internal(sk, mu, rnd)
+  return sigma
+
+
+ExternalMu-ML-DSA.Sign_internal(sk, mu, rnd):
+   ... identical to FIPS 204 Algorithm 7, but with Line 6 removed.
+~~~
+{: #fig-externalmu-ml-dsa-internal title="Internal steps of ExternalMu-ML-DSA"}
+
 # IANA Considerations
 
 For the ASN.1 module in {asn1}, IANA is requested to assign an object

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -397,7 +397,7 @@ textual encoding defined in {{RFC7468}}.
 # Pre-hashed mode (ExternalMu-ML-DSA)
 
 
-Many applications will require a "pre-hashed" mode of ML-DSA whereby a message digest can be pre-computed outside of the cryptographic module and then only a small fixed-width hash value is passed to the crypto module.
+Many applications will require a "pre-hashed" mode of ML-DSA whereby the signature generation process can be separated into a pre-hash step and a core signature step in order to ease operational requirements around large or inconsistently-sized payloads.
 Many applications and protocols include message digesting, but there exist some that do not. Examples of this can be found even within [RFC5280]; for example certificate and certificate revocation list (CRL) data structures do not include message digesting and therefore become problematic when producing large CRLs or when signing a high volume of certificates containing large public keys. Such situations require pre-hashing to be performed by the signature primitive.
 
 


### PR DESCRIPTION
Adds the real pre-hash mode and forbids the FIPS 204 HashML-DSA section 5.4 mode.