### PR TITLE
Allow for HashML-DSA only in the pub key of EE certs and define ctx

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -220,7 +220,7 @@ The OIDs are:
 The contents of the parameters component for each algorithm MUST be
 absent. The ctx value used in the ML-DSA signing and verification 
 {{FIPS204}} of ML-DSA signatures defined in this specification 
-(X.509 certificates, CRLs) is the empty string 
+(X.509 certificates, CRLs) is the empty string.
 
 # ML-DSA Signatures in PKIX
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -444,7 +444,7 @@ ExternalMu-ML-DSA.Prehash(pk, M, ctx):
 
   if |ctx| > 255 then
     return error  # return an error indication if the context string is
-                  # not too long
+                  # too long
   end if
 
   M' = BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|ctx|, 1)

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -218,8 +218,9 @@ The OIDs are:
 ~~~
 
 The contents of the parameters component for each algorithm MUST be
-absent. The ctx value used in the ML-DSA Signing and Verification 
-{{FIPS204}} is the empty string 
+absent. The ctx value used in the ML-DSA signing and verification 
+{{FIPS204}} of ML-DSA signatures defined in this specification 
+(X.509 certificates, CRLs) is the empty string 
 
 # ML-DSA Signatures in PKIX
 
@@ -428,7 +429,10 @@ defined in [FIPS204] section 5.4. This specification uses exclusively
 ExternalMu-ML-DSA for pre-hashed use cases, and thus public
 keys identified by `id-hash-ml-dsa-44-with-sha512`,
 `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512`
-MUST NOT be used in X.509 and related PKIX protocols.
+MUST NOT be used in X.509 and related PKIX protocols with the 
+exception of the Public Key in end-entity X.509 certifacates. 
+Such public keys could be used beyond PKIX use-cases and thus 
+could need HashML-DSA. 
 
 All functions and notation used in {{fig-externalmu-ml-dsa-external}}
 and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -429,10 +429,10 @@ defined in [FIPS204] section 5.4. This specification uses exclusively
 ExternalMu-ML-DSA for pre-hashed use cases, and thus public
 keys identified by `id-hash-ml-dsa-44-with-sha512`,
 `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512`
-MUST NOT be used in X.509 and related PKIX protocols with the 
-exception of the Public Key in end-entity X.509 certifacates. 
-Such public keys could be used beyond PKIX use-cases and thus 
-could need HashML-DSA. 
+MUST NOT be used in X.509 and related PKIX protocols with the
+exception of the Public Key in end-entity X.509 certifacates.
+Such public keys could be used beyond PKIX use-cases and thus
+could need HashML-DSA.
 
 All functions and notation used in {{fig-externalmu-ml-dsa-external}}
 and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -218,8 +218,8 @@ The OIDs are:
 ~~~
 
 The contents of the parameters component for each algorithm MUST be
-absent. The ctx value used in the ML-DSA signing and verification 
-{{FIPS204}} of ML-DSA signatures defined in this specification 
+absent. The ctx value used in the ML-DSA signing and verification
+{{FIPS204}} of ML-DSA signatures defined in this specification
 (X.509 certificates, CRLs) is the empty string.
 
 # ML-DSA Signatures in PKIX

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -442,9 +442,9 @@ External operations:
 ~~~
 ExternalMu-ML-DSA.Prehash(pk, M, ctx):
 
-  if |ctx| > 0 then
+  if |ctx| > 255 then
     return error  # return an error indication if the context string is
-                  # not the empty string
+                  # not too long
   end if
 
   M' = BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|ctx|, 1)

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -431,8 +431,7 @@ keys identified by `id-hash-ml-dsa-44-with-sha512`,
 `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512`
 MUST NOT be used in X.509 and related PKIX protocols with the
 exception of the Public Key in end-entity X.509 certifacates.
-Such public keys could be used beyond PKIX use-cases and thus
-could need HashML-DSA.
+Such public keys could be used beyond PKIX.
 
 All functions and notation used in {{fig-externalmu-ml-dsa-external}}
 and {{fig-externalmu-ml-dsa-internal}} are defined in [FIPS204].

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -218,7 +218,8 @@ The OIDs are:
 ~~~
 
 The contents of the parameters component for each algorithm MUST be
-absent.
+absent. The ctx value used in the ML-DSA Signing and Verification 
+{{FIPS204}} is the empty string 
 
 # ML-DSA Signatures in PKIX
 
@@ -437,9 +438,9 @@ External operations:
 ~~~
 ExternalMu-ML-DSA.Prehash(pk, M, ctx):
 
-  if |ctx| > 255 then
+  if |ctx| > 0 then
     return error  # return an error indication if the context string is
-                  # too long
+                  # not the empty string
   end if
 
   M' = BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|ctx|, 1)


### PR DESCRIPTION
- ctx = empty string
- Prescribe PureML-DSA OIDS only except for the public key of EE certs which could be used beyond PKIX for use-cases we are not aware of. 