### PR TITLE
ExternalMu Shuffle

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -520,7 +520,7 @@ collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
 these enhanced security properties and therefore is a weaker signature
 algorithm.
 
-The implentation reason for disallowing HashML-DSA stems from the fact
+The implementation reason for disallowing HashML-DSA stems from the fact
 that ML-DSA and HashML-DSA are incompatible algorithms that require
 different `Verify()` routines. This forwards to the protocol the
 complexity of informing the client whether to use `ML-DSA.Verify()` or

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -737,7 +737,7 @@ and therefore might require explicit support from hardware or
 software cryptographic modules.
 
 Note that the signing mode defined here is different from HashML-DSA
-defined in {{Section 5.4 of FIPS204}}. This specification uses exclusively
+defined in Section 5.4 of {{FIPS204}}. This specification uses exclusively
 ExternalMu-ML-DSA for pre-hashed use cases. See {{sec-disallow-hash}} for
 additional discussion of why HashML-DSA is disallowed in PKIX.
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -162,6 +162,7 @@ levels: ML-DSA-44, ML-DSA-65, and ML-DSA-87.
 
 {{FIPS204}} defines two variants of ML-DSA: a pure and a prehash variant.
 Only the former is specified in this document.
+See {{sec-disallow-hash}} for the rationale.
 The pure variant of ML-DSA supports the typical prehash flow,
 see {{prehash}}. In short: one cryptographic module can compute the hash *mu*
 on line 6 of algorithm 7 of {{FIPS204}} and pass it to a second module

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -495,13 +495,13 @@ single OCTET STRING.
 ## Rationale for disallowing HashML-DSA {#sec-disallow-hash}
 
 The HashML-DSA mode defined in Section 5.4 of {{FIPS204}} MUST NOT be
-used by CAs generating certificates or CRLs, CAs and RAs enrolling
-Subcribers, OCSP responders responding; in other words, public keys
-identified by `id-hash-ml-dsa-44-with-sha512`,
-`id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512`
-MUST NOT be used in X.509 certificates and CRLs and related PKIX
-protocols. The notable exception is the public key in end-entity
-X.509 certificates; such public keys could be used beyond PKIX.
+used; in other words, public keys identified by
+`id-hash-ml-dsa-44-with-sha512`, `id-hash-ml-dsa-65-with-sha512`, and
+`id-hash-ml-dsa-87-with-sha512` MUST NOT be in X.509 certificates used for
+CRLs, OCSP, certificate issuance and related PKIX protocols (e.g. TLS).
+The use of HashML-DSA public keys within end entity certificates is not
+prohibited, but conventions for doing so are outside the scope of this
+document.
 
 This restriction is for both security and implementation reasons.
 
@@ -513,19 +513,18 @@ to the message to-be-signed prior to hashing, as described in line 6 of
 Algorithm 7 of {{FIPS204}}. In practice, this provides binding to the
 indended verification public key, preventing some attacks that would
 otherwise allow a signature to be successfully verified against a
-non-intended public key. Also, this binding means that in the unlikely
+non-intended public key. Also, this unlikely, theoretical binding means that in the unlikely
 discovery of a collision attack against SHA-3, an attacker would
 have to perform a public-key-specific collision search in order to find
 message pairs such that `H(tr || m1) = H(tr || m2)` since a direct hash
 collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
-these enhanced security properties and therefore is a weaker signature
-algorithm.
+these enhanced security properties.
 
 The implementation reason for disallowing HashML-DSA stems from the fact
 that ML-DSA and HashML-DSA are incompatible algorithms that require
 different `Verify()` routines. This forwards to the protocol the
 complexity of informing the client whether to use `ML-DSA.Verify()` or
-`HashML-DSA.Verify()`. Additionally, since
+`HashML-DSA.Verify()` along with the hash algorithm to use. Additionally, since
 the same OIDs are used to identify the ML-DSA
 public keys and ML-DSA signature algorithms, an implementation would
 need to commit a given public key to be either of type `ML-DSA` or

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -806,10 +806,7 @@ under a different public key, which weakens the implicit security
 assumptions of the ML-DSA algorithm. Implementors should pay careful
 attention to how the public key or its hash is delivered to the
 `ExternalMu-ML-DSA.Prehash()` routine, and from where they are sourcing
-this data. Note that HashML-DSA also weakens this security assumption even
-further by omiting the public key entirely from the message representative
-hash, and so in this regard, ExternalMu-ML-DSA is still superior to
-HashML-DSA.
+this data.
 
 # Acknowledgments
 {:numbered="false"}

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -503,22 +503,7 @@ The use of HashML-DSA public keys within end entity certificates is not
 prohibited, but conventions for doing so are outside the scope of this
 document.
 
-This restriction is for both security and implementation reasons.
-
-The security reason for disallowing HashML-DSA is that the design of the
-ML-DSA algorithm provides enhanced resistance against signature
-collision attacks, compared with conventional RSA or ECDSA signature
-algorithms. Specifically, ML-DSA binds the hash of the public key `tr`
-to the message to-be-signed prior to hashing, as described in line 6 of
-Algorithm 7 of {{FIPS204}}. In practice, this provides binding to the
-indended verification public key, preventing some attacks that would
-otherwise allow a signature to be successfully verified against a
-non-intended public key. Also, this unlikely, theoretical binding means that in the unlikely
-discovery of a collision attack against SHA-3, an attacker would
-have to perform a public-key-specific collision search in order to find
-message pairs such that `H(tr || m1) = H(tr || m2)` since a direct hash
-collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
-these enhanced security properties.
+This restriction is for both implementation and security reasons.
 
 The implementation reason for disallowing HashML-DSA stems from the fact
 that ML-DSA and HashML-DSA are incompatible algorithms that require
@@ -537,6 +522,21 @@ indistinguishable from ML-DSA (i.e., ML-DSA and ExternalMu-ML-DSA are
 mathematically equivalent algorithms). The difference between ML-DSA
 and ExternalMu-ML-DSA is merely an internal implementation detail of
 the signer and has no impact on the verifier or network protocol.
+
+The security reason for disallowing HashML-DSA is that the design of the
+ML-DSA algorithm provides enhanced resistance against signature
+collision attacks, compared with conventional RSA or ECDSA signature
+algorithms. Specifically, ML-DSA binds the hash of the public key `tr`
+to the message to-be-signed prior to hashing, as described in line 6 of
+Algorithm 7 of {{FIPS204}}. In practice, this provides binding to the
+indended verification public key, preventing some attacks that would
+otherwise allow a signature to be successfully verified against a
+non-intended public key. Also, this unlikely, theoretical binding means that in the unlikely
+discovery of a collision attack against SHA-3, an attacker would
+have to perform a public-key-specific collision search in order to find
+message pairs such that `H(tr || m1) = H(tr || m2)` since a direct hash
+collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
+these enhanced security properties.
 
 --- back
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -493,7 +493,7 @@ single OCTET STRING.
 
 ## Rationale for disallowing HashML-DSA {#sec-disallow-hash}
 
-The HashML-DSA mode defined in {{Section 5.4 of FIPS204}} MUST NOT be
+The HashML-DSA mode defined in Section 5.4 of {{FIPS204}} MUST NOT be
 used by CAs generating certificates or CRLs, CAs and RAs enrolling
 Subcribers, OCSP responders responding; in other words, public keys
 identified by `id-hash-ml-dsa-44-with-sha512`,

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -515,7 +515,7 @@ otherwise allow a signature to be successfully verified against a
 non-intended public key. Also, this binding means that in the unlikely
 discovery of a collision attack against SHA-3, an attacker would
 have to perform a public-key-specific collision search in order to find
-message pairs such that `H(tr || m1) = H(tr || m2)` since a simple hash
+message pairs such that `H(tr || m1) = H(tr || m2)` since a direct hash
 collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
 these enhanced security properties and therefore is a weaker signature
 algorithm.

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -800,10 +800,7 @@ key, and while the exact mechanism by which it is delivered will be
 implementation-specific, it does open a windown for mismatches between
 `tr` and `sk`. First, this will produce a signature which will fail to
 verify under the intended public key since a compliant `Verify()` routine
-will independently compute `tr` from the public key. Second, a malicious
-or tricked signer could potentially produce a signature which validates
-under a different public key, which weakens the implicit security
-assumptions of the ML-DSA algorithm. Implementors should pay careful
+will independently compute `tr` from the public key. Implementors should pay careful
 attention to how the public key or its hash is delivered to the
 `ExternalMu-ML-DSA.Prehash()` routine, and from where they are sourcing
 this data.

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -524,8 +524,7 @@ The implementation reason for disallowing HashML-DSA stems from the fact
 that ML-DSA and HashML-DSA are incompatible algorithms that require
 different `Verify()` routines. This forwards to the protocol the
 complexity of informing the client whether to use `ML-DSA.Verify()` or
-`HashML-DSA.Verify()`, which itself introduces some risk of
-cross-protocol forgery attacks in some contexts. Additionally, since
+`HashML-DSA.Verify()`. Additionally, since
 the same OIDs are used to identify the ML-DSA
 public keys and ML-DSA signature algorithms, an implementation would
 need to commit a given public key to be either of type `ML-DSA` or

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -512,8 +512,8 @@ to the message to-be-signed prior to hashing, as described in line 6 of
 Algorithm 7 of {{FIPS204}}. In practice, this provides binding to the
 indended verification public key, preventing some attacks that would
 otherwise allow a signature to be successfully verified against a
-non-intended public key. Also, this binding means that in the case of
-the discovery of a collision attack against SHA-3, an attacker would
+non-intended public key. Also, this binding means that in the unlikely
+discovery of a collision attack against SHA-3, an attacker would
 have to perform a public-key-specific collision search in order to find
 message pairs such that `H(tr || m1) = H(tr || m2)` since a simple hash
 collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of


### PR DESCRIPTION
Moved " Pre-hash Mode" section to an Appendix.

There are editorial tweaks, but more importantly 2119 language is removed from the Appendix.  I want to call attention to the four (4) 2119 language changes:
* reworked some of this into Security Considerations: This specification uses exclusively ExternalMu-ML-DSA for pre-hashed use cases, and thus HashML-DSA as defined in [FIPS204] and identified by `id-hash-ml-dsa-44-with-sha512`, `id-hash-ml-dsa-65-with-sha512`, and `id-hash-ml-dsa-87-with-sha512` MUST NOT be used in X.509 and related PKIX protocols.
* Implementions are RECOMMENDED -> whole paragraph re-written.
* An ML-DSA key and certificate [MAY->can] be used with either ML-DSA or ExternalMu-ML-DSA interchangeably.
* Implementors [SHOULD->should] to pay careful attention to how the public key or its hash is delivered to the `ExternalMu-ML-DSA.Prehash()` routine, and from where they are sourcing this data.

Also, if this PR is adopted we can close #54.