### PR TITLE
Address checks on expanded private key

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -567,6 +567,9 @@ ensure that the sender properly generated the private key.
 If the check is done and the seed and the expandedKey are not consistent,
 the recipient MUST reject the private key as malformed.
 
+For interopability it is RECOMMENDED that no further checks
+are performed on the `expandedKey`.
+
 # Security Considerations
 
 The Security Considerations section of {{RFC5280}} applies to this


### PR DESCRIPTION
This should address #106

I think we can drop the normative language if that's preferred.

We could add normative language around checking s and t consistency, but I guess that would be more of a hassle at this point.