### PR TITLE
Polishing of the HashML-DSA collision risk text

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -708,7 +708,7 @@ immaterial. That is because a hash of the issuing CA's public key
 is already included in the Authority Key Identifier (AKI) extension which
 is signed as part of the tbsCertificate structure.
 Although it is a SHA-1 hash, general second pre-images against
-the AKI hash of existing issuing CAs would be impractical. 
+the AKI hash of existing issuing CAs would be impractical.
 
 --- back
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -707,7 +707,7 @@ security risk of using HashML-DSA in X.509 signatures would be
 immaterial. That is because a hash of the issuing CA's public key
 is already included in the Authority Key Identifier (AKI) extension which
 is signed as part of the tbsCertificate structure.
-Although it is a SHA-1 hash, general second pre-images against
+Even when it is a SHA-1 hash, general second pre-images against
 the AKI hash of existing issuing CAs would be impractical.
 
 --- back

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -702,6 +702,13 @@ would have to perform a public-key-specific collision search in order
 to find message pairs such that `H(tr || m1) = H(tr || m2)` since a
 direct hash collision `H(m1) = H(m2)` will not suffice.
 HashML-DSA removes this enhanced security property.
+In spite of its lack of targeted collision protection, the practical
+security risk of using HashML-DSA in X.509 signatures would be
+immaterial. That is because a hash of the issuing CA's public key
+is already included in the Authority Key Identifier (AKI) extension which
+is signed as part of the tbsCertificate structure.
+Although it is a SHA-1 hash, general second pre-images against
+the AKI hash of existing issuing CAs would be impractical. 
 
 --- back
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -692,19 +692,16 @@ and ExternalMu-ML-DSA is merely an internal implementation detail of
 the signer and has no impact on the verifier or network protocol.
 
 The security reason for disallowing HashML-DSA is that the design of the
-ML-DSA algorithm provides enhanced resistance against signature
-collision attacks, compared with conventional RSA or ECDSA signature
-algorithms. Specifically, ML-DSA binds the hash of the public key `tr`
-to the message to-be-signed prior to hashing, as described in line 6 of
-Algorithm 7 of {{FIPS204}}. In practice, this provides binding to the
-intended verification public key, preventing some attacks that would
-otherwise allow a signature to be successfully verified against a
-non-intended public key. Also, this unlikely, theoretical binding means that in the unlikely
-discovery of a collision attack against SHA-3, an attacker would
-have to perform a public-key-specific collision search in order to find
-message pairs such that `H(tr || m1) = H(tr || m2)` since a direct hash
-collision `H(m1) = H(m2)` will not suffice. HashML-DSA removes both of
-these enhanced security properties.
+ML-DSA algorithm provides enhanced resistance against collision attacks,
+compared with HashML-DSA or conventional RSA or ECDSA signature algorithms.
+Specifically, ML-DSA prepends the hash of the public key `tr`
+to the message to-be-signed prior to hashing, as described in
+line 6 of Algorithm 7 of {{FIPS204}}. This means that in the unlikely
+discovery of a collision attack against the SHA-3 family, an attacker
+would have to perform a public-key-specific collision search in order
+to find message pairs such that `H(tr || m1) = H(tr || m2)` since a
+direct hash collision `H(m1) = H(m2)` will not suffice.
+HashML-DSA removes this enhanced security property.
 
 --- back
 

--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -694,7 +694,7 @@ the signer and has no impact on the verifier or network protocol.
 The security reason for disallowing HashML-DSA is that the design of the
 ML-DSA algorithm provides enhanced resistance against collision attacks,
 compared with HashML-DSA or conventional RSA or ECDSA signature algorithms.
-Specifically, ML-DSA prepends the hash of the public key `tr`
+Specifically, ML-DSA prepends the SHAKE256 hash of the public key `tr`
 to the message to-be-signed prior to hashing, as described in
 line 6 of Algorithm 7 of {{FIPS204}}. This means that in the unlikely
 discovery of a collision attack against the SHA-3 family, an attacker


### PR DESCRIPTION
- Updating paragraph to break down the ML-DSA vs HashML-DSA targeted collision vs general collision risk. 
- Removing the unclear sentence that makes HashML-DSA look like it is not binding the public key to the signed message / hash of the message.