### PR TITLE
Nit: expand MLDSA acronym in title

### DIFF
--- a/draft-ietf-lamps-dilithium-certificates.md
+++ b/draft-ietf-lamps-dilithium-certificates.md
@@ -1,6 +1,7 @@
 ---
 title: >
-  Internet X.509 Public Key Infrastructure: Algorithm Identifiers for ML-DSA
+  Internet X.509 Public Key Infrastructure - Algorithm Identifiers
+  for the Module-Lattice-Based Digital Signature Algorithm (ML-DSA)
 abbrev: ML-DSA in Certificates
 category: std
 


### PR DESCRIPTION
Considering unifying the naming conventions across the two drafts, as in https://github.com/lamps-wg/kyber-certificates/blob/main/draft-ietf-lamps-kyber-certificates.md?plain=1#L3-L4

Using both the full scheme name and acronym (ML-DSA) may also improve visibility/discovery.