### PR TITLE
Fix ML-DSA-87-PublicKey size

### DIFF
--- a/X509-ML-DSA-2025.asn
+++ b/X509-ML-DSA-2025.asn
@@ -105,7 +105,7 @@ ML-DSA-44-PublicKey ::= OCTET STRING (SIZE (1312))
 
 ML-DSA-65-PublicKey ::= OCTET STRING (SIZE (1952))
 
-ML-DSA-87-PublicKey ::= OCTET STRING (SIZE (2602))
+ML-DSA-87-PublicKey ::= OCTET STRING (SIZE (2592))
 
 --
 -- Signature Algorithms


### PR DESCRIPTION
While looking at `X509-ML-DSA-2025.asn`, I noticed: 

```
pk-ml-dsa-44 PUBLIC-KEY ::= {
  IDENTIFIER id-ml-dsa-44
  -- KEY no ASN.1 wrapping; 1312 octets --
[...]
pk-ml-dsa-65 PUBLIC-KEY ::= {
  IDENTIFIER id-ml-dsa-65
  -- KEY no ASN.1 wrapping; 1952 octets --
[...]
pk-ml-dsa-87 PUBLIC-KEY ::= {
  IDENTIFIER id-ml-dsa-87
  -- KEY no ASN.1 wrapping; 2592 octets --
[...]
ML-DSA-44-PublicKey ::= OCTET STRING (SIZE (1312))

ML-DSA-65-PublicKey ::= OCTET STRING (SIZE (1952))

ML-DSA-87-PublicKey ::= OCTET STRING (SIZE (2602))
```

The `2602` value for `ML-DSA-87-PublicKey` should be `2592` to be consistent with the comment in `pk-ml-dsa-87` and the table in section `Security Strengths` (see below).

```
|=======+=======+=====+========+========+==========+==========|
| Level | (k,l) | eta |  Sig.  | Public | Private  | Private  |
|       |       |     |  (B)   | Key(B) | Seed(B)  | Expand(B)|
|=======+=======+=====+========+========+==========+==========|
|   2   | (4,4) |  2  |  2420  |  1312  |    32    |   2560   |
|   3   | (6,5) |  4  |  3309  |  1952  |    32    |   4032   |
|   5   | (8,7) |  2  |  4627  |  2592  |    32    |   4896   |
|=======+=======+=====+========+========+==========+==========|
```



